### PR TITLE
add custom targeting support

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -33,7 +33,7 @@ export default class Example extends Component {
   constructor() {
     super();
     this.state = {
-      fluidSizeIndex: 0,
+      fluidSizeIndex: 0
     };
   }
 
@@ -148,6 +148,7 @@ export default class Example extends Component {
             <PublisherBanner
               adSize="banner"
               validAdSizes={['banner', 'largeBanner', 'mediumRectangle']}
+              customTargeting= {{"test1": "hello1", "test2": "hello2"}}
               adUnitID="/6499/example/APIDemo/AdSizes"
               ref={el => (this._adSizesExample = el)}
             />
@@ -159,7 +160,7 @@ export default class Example extends Component {
           <BannerExample title="DFP - App Events" style={this.state.appEventsExampleStyle}>
             <PublisherBanner
               style={{ height: 50 }}
-              adUnitID="/6499/example/APIDemo/AppEvents"
+              adUnitID="/6499/example/APIDem`o/AppEvents"
               onAdFailedToLoad={(error) => console.warn(error)}
               onAppEvent={(event) => {
                 if (event.name === 'color') {

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -5,7 +5,7 @@ import {
   findNodeHandle,
   ViewPropTypes,
 } from 'react-native';
-import { string, func, arrayOf } from 'prop-types';
+import { string, func, arrayOf, object} from 'prop-types';
 
 import { createErrorFromErrorData } from './utils';
 
@@ -87,6 +87,11 @@ PublisherBanner.propTypes = {
    * banner is default
    */
   adSize: string,
+
+  /**
+   * make it as json?
+   */
+  customTargeting: object,
 
   /**
    * Optional array specifying all valid sizes that are appropriate for this slot.

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, copy) NSArray *validAdSizes;
 @property (nonatomic, copy) NSArray *testDevices;
+@property (nonatomic, copy) NSDictionary *customTargeting;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -53,8 +53,15 @@
 #pragma clang diagnostic pop
 
 - (void)loadBanner {
-    GADRequest *request = [GADRequest request];
+    DFPRequest *request = [DFPRequest request];
     request.testDevices = _testDevices;
+    
+    if (_customTargeting != nil) {
+        if (_customTargeting.count > 0) {
+            request.customTargeting = _customTargeting;
+        }
+    }
+    
     [_bannerView loadRequest:request];
 }
 
@@ -75,6 +82,11 @@
 - (void)setTestDevices:(NSArray *)testDevices
 {
     _testDevices = RNAdMobProcessTestDevices(testDevices, kDFPSimulatorID);
+}
+
+- (void)setCustomTargeting:(NSDictionary *)customTargeting
+{
+    _customTargeting = customTargeting;
 }
 
 -(void)layoutSubviews

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -36,6 +36,7 @@ RCT_REMAP_VIEW_PROPERTY(adSize, _bannerView.adSize, GADAdSize)
 RCT_REMAP_VIEW_PROPERTY(adUnitID, _bannerView.adUnitID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(customTargeting, NSDictionary)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)


### PR DESCRIPTION
add custom targeting support for iOS

Example:
```
<PublisherBanner
  adSize="banner"
  validAdSizes={['banner', 'largeBanner', 'mediumRectangle']}
  customTargeting= {{"test1": "hello1", "test2": "hello2"}}
  adUnitID="/6499/example/APIDemo/AdSizes"
  ref={el => (this._adSizesExample = el)}
/>
```